### PR TITLE
Add optional npm registy

### DIFF
--- a/flowforge-docker/Dockerfile
+++ b/flowforge-docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:16-alpine
 
+ARG REGISTRY
+RUN if [[ ! -z "$REGISTRY" ]] ; then npm config set @flowforge:registry "$REGISTRY"; fi
+
 RUN apk add --no-cache --virtual build-base g++ make py3-pip sqlite-dev python2
 
 WORKDIR /usr/src/forge

--- a/node-red-container/Dockerfile
+++ b/node-red-container/Dockerfile
@@ -1,5 +1,8 @@
 FROM nodered/node-red:latest
 
+ARG REGISTRY
+RUN if [[ ! -z "$REGISTRY" ]] ; then npm config set @flowforge:registry "$REGISTRY"; fi
+
 COPY package.json /data
 WORKDIR /data
 RUN npm install


### PR DESCRIPTION
Setting the REGISTRY build arg will set it as the scoped registry for @flowforge when building the container

This helps for build test containers from private repos