### PR TITLE
Fix node red path

### DIFF
--- a/flowforge-docker/Dockerfile
+++ b/flowforge-docker/Dockerfile
@@ -13,6 +13,15 @@ RUN npm install --production --no-audit --no-fund
 
 ENV FLOWFORGE_HOME=/usr/src/forge
 
+LABEL org.label-schema.name="Flowforge Docker" \
+    org.label-schema.url="https://flowforge.com" \
+    org.label-schema.vcs-type="Git" \
+    org.label-schema.vcs-url="https://github.com/flowforge/docker-compose" \
+    org.label-schema.docker.dockerfile="flowforge-docker/Dockerfile" \
+    org.schema-label.description="Collaborative, low code integration and automation environment" \
+    authors="Flowforge Inc."
+
+
 EXPOSE 3000
 
 CMD ["./node_modules/.bin/flowforge"]

--- a/node-red-container/Dockerfile
+++ b/node-red-container/Dockerfile
@@ -19,4 +19,4 @@ ENV NODE_PATH=/usr/src/node-red
 
 EXPOSE 2880
 
-ENTRYPOINT ["./node_modules/.bin/flowforge-node-red", "-p", "2880"]
+ENTRYPOINT ["./node_modules/.bin/flowforge-node-red", "-p", "2880", "-n", "/usr/src/node-red"]


### PR DESCRIPTION
This forces nr-launcher to use the version of Node-RED in the base image, not the one in it's dependencies