### PR TITLE
Add step to the build action to push README.md

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -36,3 +36,9 @@ jobs:
           platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+      - name: Push README
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          repository: flowforge/forge-docker
+          username: flowforge
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}


### PR DESCRIPTION
This pushes the current README.md to docker hub when we tag a release