### PR TITLE
Fix path to README.md for docker hub publish

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -42,3 +42,5 @@ jobs:
           repository: flowforge/forge-docker
           username: flowforge
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          readme-filepath: docker-compose/README.md
+          


### PR DESCRIPTION
Fix path to README files when pushing to Dockerhub

fixes #48 