### PR TITLE
Fix fileStore hostname

### DIFF
--- a/etc/flowforge.yml
+++ b/etc/flowforge.yml
@@ -76,4 +76,4 @@ broker:
   public_url: ws://mqtt.example.com
 
 fileStore:
-  url: http://file-store:3001
+  url: http://file-server:3001


### PR DESCRIPTION
Change default hostname configuration for fileStore with `file-server` to work out of the box
Another solution is to change something in multiple docker-compose.yml files like the service name

Without that this error occurs in writing a file
`[error] failed to append to file: Error: Unknown Error`