### PR TITLE
Fix default context configuration

### DIFF
--- a/etc/flowforge-storage.yml
+++ b/etc/flowforge-storage.yml
@@ -13,5 +13,5 @@ context:
     type: postgres
     host: postgres
     database: ff-context
-    user: forge
+    username: forge
     password: secret


### PR DESCRIPTION
Change context.options.user to context.options.username

Otherwise the connection fails with
```ERROR: Failed to start: SequelizeConnectionError: no PostgreSQL user name specified in startup packet```