### PR TITLE
Fix identifiers with double quotes needed for the db name

### DIFF
--- a/setup-context-db.sh
+++ b/setup-context-db.sh
@@ -3,6 +3,6 @@
 set -e
 
 psql -v ON_ERROR_STOP=1 -U root <<-ESQL
-  CREATE DATABASE ff-context;
-  GRANT ALL PRIVILEGES ON DATABASE ff-context TO forge;
+  CREATE DATABASE "ff-context";
+  GRANT ALL PRIVILEGES ON DATABASE "ff-context" TO "forge";
 ESQL


### PR DESCRIPTION
Add double quotes

Avoid error
```
ERROR:  syntax error at or near "-"
```