### PR TITLE
Only create DB if it doesn't exist

### DIFF
--- a/setup-context-db.sh
+++ b/setup-context-db.sh
@@ -3,6 +3,6 @@
 set -e
 
 psql -v ON_ERROR_STOP=1 -U root <<-ESQL
-  CREATE DATABASE "ff-context";
+  SELECT 'CREATE DATABASE "ff-context"' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'ff-context')\gexec
   GRANT ALL PRIVILEGES ON DATABASE "ff-context" TO "forge";
 ESQL


### PR DESCRIPTION
## Description

Only create context db if it doesn't exist.

## Related Issue(s)

flowforge/flowforge#1524

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

