### PR TITLE
Add config to set max body size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "/var/run/docker.sock:/tmp/docker.sock:ro"
       - "./nginx/vhost.d:/etc/nginx/vhost.d"
       - "./nginx/html:/usr/share/nginx/html"
+      - "./nginx/my-proxy.conf:/etc/nginx/conf.d/my_proxy.conf"
       # - "./certs:/etc/nginx/certs"
     ports:
       - "80:80"

--- a/nginx/my-proxy.conf
+++ b/nginx/my-proxy.conf
@@ -1,0 +1,1 @@
+client_max_body_size 5m;


### PR DESCRIPTION
fixes #92

## Description

<!-- Describe your changes in detail -->
Default nginx max client body size is 1m, Node-RED defaults to 5m 

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#92

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

