### PR TITLE
ensure acme-companion restarts on failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       # - "HTTPS_METHOD=redirect"
   # acme:
   #   image: nginxproxy/acme-companion
+  #   restart: always
   #   volumes:
   #     - "/var/run/docker.sock:/var/run/docker.sock:ro"
   #     - "./acme:/etc/acme.sh"


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Make sure the acme-companion restarts if it fails so new certs are created.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

